### PR TITLE
Update build process for v0.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,26 @@ The tool checks if given node p2p port is responsive, by connecting and doing th
 
 ## Build
 
+### Local
+
 ```bash
-cd apps/cudos-p2p-scan
 go build
 ```
 
+### Direct from GitHub repo
+
+```bash
+go install -v github.com/CudoVentures/cudos-p2p-scan@latest
+```
+
+### Binary
+
+Binary will be written to ```~/go/bin/cudos-p2p-scan```
 
 ## Run
 
 ```bash
-./cudos-p2p-scan TargetHost:26656
+~/go/bin/cudos-p2p-scan <Target Host>:<Target port usually 26656>
 ```
 
 Example output:


### PR DESCRIPTION
Fix for [Remote build string is unnecessarily long #1](https://github.com/CudoVentures/cudos-p2p-scan/issues/1)